### PR TITLE
Get JSONField from django

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-user-defined-fields
-version = 0.0.9
+version = 0.0.10
 description = A Django app for user defined fields
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-user-defined-fields
-version = 0.0.8
+version = 0.0.9
 description = A Django app for user defined fields
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/userdefinedfields/__init__.py
+++ b/userdefinedfields/__init__.py
@@ -1,5 +1,5 @@
 name = "django-user-defined-fields"
 
-VERSION = (0, 0, 8)
+VERSION = (0, 0, 9)
 
 __version__ = '.'.join(str(x) for x in VERSION[:(2 if VERSION[2] == 0 else 3)]) # noqa

--- a/userdefinedfields/__init__.py
+++ b/userdefinedfields/__init__.py
@@ -1,5 +1,5 @@
 name = "django-user-defined-fields"
 
-VERSION = (0, 0, 7)
+VERSION = (0, 0, 8)
 
 __version__ = '.'.join(str(x) for x in VERSION[:(2 if VERSION[2] == 0 else 3)]) # noqa

--- a/userdefinedfields/__init__.py
+++ b/userdefinedfields/__init__.py
@@ -1,5 +1,5 @@
 name = "django-user-defined-fields"
 
-VERSION = (0, 0, 9)
+VERSION = (0, 0, 10)
 
 __version__ = '.'.join(str(x) for x in VERSION[:(2 if VERSION[2] == 0 else 3)]) # noqa

--- a/userdefinedfields/context_processors.py
+++ b/userdefinedfields/context_processors.py
@@ -20,6 +20,7 @@ def get_extra_fields():
             'settings': field.field_settings,
             'conditions': conditions[field.id],
             'help_text': field.help_text,
+            'is_required': field.is_required,
         })
 
     return extra_fields

--- a/userdefinedfields/fields.py
+++ b/userdefinedfields/fields.py
@@ -1,7 +1,7 @@
 from functools import partialmethod
 
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 
 from .models import ExtraField
 

--- a/userdefinedfields/forms.py
+++ b/userdefinedfields/forms.py
@@ -1,4 +1,4 @@
-from django.contrib.postgres.forms import JSONField
+from django.forms import JSONField
 
 from .widgets import ExtraFieldsInput
 

--- a/userdefinedfields/migrations/0001_initial.py
+++ b/userdefinedfields/migrations/0001_initial.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
                 ('required', models.BooleanField(default=False, verbose_name='Should field be required?')),
                 ('help_text', models.CharField(blank=True, max_length=300)),
                 ('content_type', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='contenttypes.ContentType')),
-                ('field_settings', django.contrib.postgres.fields.jsonb.JSONField(blank=True, default=dict)),
+                ('field_settings', models.jsonb.JSONField(blank=True, default=dict)),
             ],
             options={
                 'ordering': ('content_type', 'group', 'order'),

--- a/userdefinedfields/models.py
+++ b/userdefinedfields/models.py
@@ -1,4 +1,3 @@
-from django.contrib.postgres.fields import JSONField
 from django.db import models
 
 
@@ -15,7 +14,7 @@ class ExtraField(models.Model):
     order = models.IntegerField(default=0)
     label = models.CharField('Display name', max_length=50)
     name = models.SlugField()
-    field_settings = JSONField(default=dict, blank=True)
+    field_settings = models.JSONField(default=dict, blank=True)
     widget = models.CharField(max_length=32, default='text', choices=WIDGET_CHOICES)
     default = models.CharField(max_length=1024, blank=True, default='')
     in_list = models.BooleanField('Show in list view?', default=True)


### PR DESCRIPTION
Django 3.1 deprecating JSONField from contrib.postgres.

Updates imports to point to django.models / django.fields.