### PR TITLE
fix: Fixed contribute_to_class not sending self as first arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "django-user-defined-fields"
-version = "0.0.20"
+version = "0.0.21"
 description = "A Django app for user defined fields"
 authors = ["Aidan Lister <aidan@uptickhq.com>"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/uptick/django-user-defined-fields/"
 repository = "https://github.com/uptick/django-user-defined-fields/"
-keywords = ["django","custom","fields","json"]
+keywords = ["django", "custom", "fields", "json"]
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
@@ -23,12 +23,8 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]
-include = [
-    "LICENSE",
-]
-packages = [
-    { include = "userdefinedfields"}
-]
+include = ["LICENSE"]
+packages = [{ include = "userdefinedfields" }]
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"
@@ -49,9 +45,16 @@ experimental_string_processing = true
 
 [tool.isort]
 known_django = "django"
-sections = ["FUTURE","STDLIB","THIRDPARTY","DJANGO","FIRSTPARTY","LOCALFOLDER"]
+sections = [
+    "FUTURE",
+    "STDLIB",
+    "THIRDPARTY",
+    "DJANGO",
+    "FIRSTPARTY",
+    "LOCALFOLDER",
+]
 default_section = "THIRDPARTY"
-known_standard_library = ["six","tablib","yaml"]
+known_standard_library = ["six", "tablib", "yaml"]
 known_first_party = "userdefinedfields"
 multi_line_output = 3
 line_length = 100

--- a/userdefinedfields/fields.py
+++ b/userdefinedfields/fields.py
@@ -9,6 +9,13 @@ from django.db.models.fields.related import ForeignKey
 from .models import ExtraField
 
 
+class partialmethod_with_self(partialmethod):
+    """Backwards compatible fix for bug in python 3.11 https://github.com/python/cpython/issues/99152"""
+
+    def __get__(self, obj, cls=None):
+        return self._make_unbound_method().__get__(obj, cls)
+
+
 class ExtraFieldsJSONField(JSONField):
     def __init__(self, *args, **kwargs):
         kwargs["default"] = kwargs.get("default", dict)
@@ -130,11 +137,11 @@ class ExtraFieldsJSONField(JSONField):
         setattr(
             cls,
             f"get_{name}_display",
-            partialmethod(self._get_EXTRAFIELD_display, field=self),
+            partialmethod_with_self(self._get_EXTRAFIELD_display, field=self),
         )
         setattr(
             cls,
             f"get_{name}_fieldlist",
-            partialmethod(self._get_EXTRAFIELD_fieldlist, field=self),
+            partialmethod_with_self(self._get_EXTRAFIELD_fieldlist, field=self),
         )
         super().contribute_to_class(cls, name)


### PR DESCRIPTION
Bug in python 3.11: https://github.com/python/cpython/issues/99152

functools.partialmethod does not send self when defined on an instance method and applied to another instance.

This is a backwards compatible fix so it should be fine for 3.10 and below.

We should remove this when it is fixed upstream.

This PR is required to bump up workforce to python3.11