### PR TITLE
fix: support new factory-boy v3 import alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-user-defined-fields"
-version = "0.0.21"
+version = "0.0.22"
 description = "A Django app for user defined fields"
 authors = ["Aidan Lister <aidan@uptickhq.com>"]
 license = "MIT"

--- a/userdefinedfields/factories.py
+++ b/userdefinedfields/factories.py
@@ -6,12 +6,17 @@ except ImportError:
     sys.stderr.write("Use of factories requires factory_boy\n")
     exit(1)
 
+try:
+    from factory.django import DjangoModelFactory
+except ImportError:
+    from factory import DjangoModelFactory
+
 from django.utils.text import slugify
 
 from .models import ExtraField
 
 
-class ExtraFieldFactory(factory.DjangoModelFactory):
+class ExtraFieldFactory(DjangoModelFactory):
     label = factory.Faker("company")
     name = factory.LazyAttribute(lambda o: slugify(o.label))
     widget = "TextInput"


### PR DESCRIPTION
factory boy v3 deprecates the `factory.DjangoModelFactory` alias in favour of `factory.django.DjangoModelFactory`

This PR attempts to import the newer alias before falling back to the old one.